### PR TITLE
Add a trigger for timeBefore

### DIFF
--- a/LedMiniDashboard/LedDashboardChild.groovy
+++ b/LedMiniDashboard/LedDashboardChild.groovy
@@ -1185,6 +1185,15 @@ void sunriseTrigger() {
 /**
  * Scheduled trigger used for rules that involve time
  */
+void timeBeforeTrigger() {
+    logInfo 'executing time before trigger'
+    notificationDispatcher()
+    subscribeAllScenarios()
+}
+
+/**
+ * Scheduled trigger used for rules that involve time
+ */
 void timeAfterTrigger() {
     logInfo 'executing time after trigger'
     notificationDispatcher()
@@ -2845,6 +2854,7 @@ private Object runClosure(final Closure template, final Map ctx) {
             ],
             delay: false
         ],
+        execute : { final Map ctx -> runOnce(getNextTime(new Date(), ctx.value as String), 'timeBeforeTrigger') },
         test    : { final Map ctx -> new Date() < (timeToday(ctx.value as String) as Date) }
     ],
     'timeAfter'         : [


### PR DESCRIPTION
Steps to reproduce bug:
1. Create a dashboard
2. Activate via After Time & Before Time
3. Set the Before Time to be 1 minute later than After Time
4. Enable "when rules stop matching, stop the effect"

Expected behaviour:
Dashboard should active at the given time and be active for exactly 1 minute.

Current behaviour:
Dashboard activates and remains active indefinitely.

Adding a trigger for Before Time causes a re-evaluation of the conditions at the desired time.