### PR TITLE
Contact sensors don't have a `motion` attribute

### DIFF
--- a/ESPHome/ESPHome-ContactSensor.groovy
+++ b/ESPHome/ESPHome-ContactSensor.groovy
@@ -139,9 +139,9 @@ public void parse(Map message) {
             // Check if the entity key matches the message entity key received to update device state
             if (settings.binarysensor as Long == message.key) {
                 String value = message.state ? 'closed' : 'open'
-                if (device.currentValue('motion') != value) {
+                if (device.currentValue('contact') != value) {
                     sendEvent([
-                        name: 'motion',
+                        name: 'contact',
                         value: value,
                         descriptionText: "Contact is ${value}"
                     ])


### PR DESCRIPTION
The Contact Sensor driver actually publishes "motion" rather than "contact," which makes it rather useless.  This publishes the correct attribute.