### PR TITLE
Rheem Water Heater

### DIFF
--- a/ESPHome/ESPHome-API-Library.groovy
+++ b/ESPHome/ESPHome-API-Library.groovy
@@ -185,6 +185,36 @@ void espHomeLightCommand(Map<String, Object> tags) {
     ], MSG_LIGHT_STATE_RESPONSE)
 }
 
+
+@CompileStatic
+void espHomeClimateCommand(Map<String, Object> tags) {
+    sendMessage(MSG_CLIMATE_COMMAND_REQUEST, [
+            1: [ tags.key as Integer, WIRETYPE_FIXED32 ],
+            2: [ tags.mode != null ? 1 : 0, WIRETYPE_VARINT ],
+            3: [ tags.mode != null ? tags.mode : 0, WIRETYPE_VARINT ],
+            4: [ tags.targetTemperature != null ? 1 : 0, WIRETYPE_VARINT ],
+            5: [ tags.targetTemperature as Float, WIRETYPE_FIXED32 ],
+            6: [ tags.targetTemperatureLow != null ? 1 : 0, WIRETYPE_VARINT ],
+            7: [ tags.targetTemperatureLow as Float, WIRETYPE_FIXED32 ],
+            8: [ tags.targetTemperatureHigh != null ? 1 : 0, WIRETYPE_VARINT ],
+            9: [ tags.targetTemperatureHigh as Float, WIRETYPE_FIXED32 ],
+            10: [ false, WIRETYPE_VARINT ], // Unused field
+            11: [ false, WIRETYPE_VARINT ], // Unused field
+            12: [ tags.fanMode != null ? 1 : 0, WIRETYPE_VARINT ],
+            13: [ tags.fanMode != null ? tags.fanMode : 0, WIRETYPE_VARINT ],
+            14: [ tags.swingMode != null ? 1 : 0, WIRETYPE_VARINT ],
+            15: [ tags.swingMode != null  ? tags.swingMode : 0, WIRETYPE_VARINT ],
+            16: [ tags.customFanMode != null ? 1 : 0, WIRETYPE_VARINT ],
+            17: [ tags.customFanMode as String, WIRETYPE_LENGTH_DELIMITED ],
+            18: [ tags.preset != null ? 1 : 0, WIRETYPE_VARINT ],
+            19: [ tags.preset != null ? tags.preset : 0, WIRETYPE_VARINT ],
+            20: [ tags.customPreset != null ? 1 : 0, WIRETYPE_VARINT ],
+            21: [ tags.customPreset as String, WIRETYPE_LENGTH_DELIMITED ],
+            22: [ tags.targetHumidity != null ? 1 : 0, WIRETYPE_VARINT ],
+            23: [ tags.targetHumidity as Float, WIRETYPE_FIXED32 ]
+    ], MSG_CLIMATE_STATE_RESPONSE)
+}
+
 @CompileStatic
 void espHomeLockCommand(Map<String, Object> tags) {
     sendMessage(MSG_LOCK_COMMAND_REQUEST, [
@@ -263,10 +293,10 @@ void espHomeSubscribeBtleRequest() {
 void espHomeSwitchCommand(Map<String, Object> tags) {
     sendMessage(MSG_SWITCH_COMMAND_REQUEST, [
             1: [ tags.key as Integer, WIRETYPE_FIXED32 ],
-            2: [ tags.state ? 1 : 0, WIRETYPE_VARINT ],
+            2: [ tags.state != null ? 1 : 0, WIRETYPE_VARINT ],
+            3: [ tags.state as String, WIRETYPE_LENGTH_DELIMITED ]
     ], MSG_SWITCH_STATE_RESPONSE)
 }
-
 /*
  * ESPHome Message Parsing
  */

--- a/ESPHome/ESPHome-API-Library.groovy
+++ b/ESPHome/ESPHome-API-Library.groovy
@@ -836,8 +836,8 @@ private static Map espHomeClimateState(Map<Integer, List> tags) {
             platform: 'climate',
             key: getLongTag(tags, 1),
             climateMode: toClimateMode(getIntTag(tags, 2)),
-            currentTemperature: getFloatTag(tags, 3),
-            targetTemperature: getFloatTag(tags, 4),
+            temperature: getFloatTag(tags, 3),  //for water heaters, upper tank temp
+            targetTemperature: getFloatTag(tags, 4), //for water heaters, set temp
             targetTemperatureLow: getFloatTag(tags, 5),
             targetTemperatureHigh: getFloatTag(tags, 6),
     ]

--- a/ESPHome/ESPHome-API-Library.groovy
+++ b/ESPHome/ESPHome-API-Library.groovy
@@ -188,6 +188,7 @@ void espHomeLightCommand(Map<String, Object> tags) {
 
 @CompileStatic
 void espHomeClimateCommand(Map<String, Object> tags) {
+
     sendMessage(MSG_CLIMATE_COMMAND_REQUEST, [
             1: [ tags.key as Integer, WIRETYPE_FIXED32 ],
             2: [ tags.mode != null ? 1 : 0, WIRETYPE_VARINT ],
@@ -870,7 +871,7 @@ private static Map espHomeClimateState(Map<Integer, List> tags) {
             targetTemperature: getFloatTag(tags, 4), //for water heaters, set temp
             targetTemperatureLow: getFloatTag(tags, 5),
             targetTemperatureHigh: getFloatTag(tags, 6),
-            customMode: getStringTag(tags, 13)
+            customPreset: getStringTag(tags, 13)
     ]
 }
 

--- a/ESPHome/ESPHome-API-Library.groovy
+++ b/ESPHome/ESPHome-API-Library.groovy
@@ -302,9 +302,17 @@ void espHomeSwitchCommand(Map<String, Object> tags) {
 @CompileStatic
 void espHomeTextCommand(Map<String, Object> tags) {
     sendMessage(MSG_TEXT_COMMAND_REQUEST, [
-            1: [ tags.key as Integer, WIRETYPE_FIXED32 ],
+            1: [ tags.key as Long, WIRETYPE_FIXED64 ],
             2: [ tags.state as String, WIRETYPE_LENGTH_DELIMITED ]
-    ], MSG_TEXT_SENSOR_STATE_RESPONSE)
+    ], MSG_TEXT_STATE_RESPONSE)
+}
+
+@CompileStatic
+void espHomeSelectCommand(Map<String, Object> tags) {
+    sendMessage(MSG_SELECT_COMMAND_REQUEST, [
+            1: [ tags.key as Long, WIRETYPE_FIXED64 ],
+            2: [ tags.state as String, WIRETYPE_LENGTH_DELIMITED ]
+    ], MSG_SELECT_STATE_RESPONSE)
 }
 
 /*
@@ -855,6 +863,18 @@ private static Map espHomeTextSensorState(Map<Integer, List> tags) {
 }
 
 @CompileStatic
+private static Map espHomeTextStateResponse(Map<Integer, List> tags) {
+    return [
+            type: 'state',
+            platform: 'text',
+            key: getLongTag(tags, 1),
+            state: getStringTag(tags, 2),
+            hasState: getBooleanTag(tags, 3, true)
+    ]
+}
+
+
+@CompileStatic
 private static boolean hasCapability(int capabilities, int capability) {
     return capabilities & capability
 }
@@ -1155,6 +1175,9 @@ private void parseMessage(ByteArrayInputStream stream, long length) {
             break
         case MSG_CLIMATE_STATE_RESPONSE:
             parse espHomeClimateState(tags)
+            break
+        case MSG_TEXT_STATE_RESPONSE:
+            parse espHomeTextStateResponse(tags)
             break
         default:
             if (!handled) {
@@ -1607,8 +1630,8 @@ private void logWarning(String s) {
 @Field static final int MSG_NUMBER_STATE_RESPONSE = 50
 @Field static final int MSG_NUMBER_COMMAND_REQUEST = 51
 @Field static final int MSG_LIST_SELECT_RESPONSE = 52
-@Field static final int MSG_SELECT_STATE_RESPONSE = 53 // TODO
-@Field static final int MSG_SELECT_COMMAND_REQUEST = 54 // TODO
+@Field static final int MSG_SELECT_STATE_RESPONSE = 53
+@Field static final int MSG_SELECT_COMMAND_REQUEST = 54
 @Field static final int MSG_LIST_SIREN_RESPONSE = 55
 @Field static final int MSG_SIREN_STATE_RESPONSE = 56
 @Field static final int MSG_SIREN_COMMAND_REQUEST = 57
@@ -1622,6 +1645,7 @@ private void logWarning(String s) {
 @Field static final int MSG_MEDIA_COMMAND_REQUEST = 65
 @Field static final int MSG_SUBSCRIBE_BTLE_REQUEST = 66
 @Field static final int MSG_BLUETOOTH_LE_RESPONSE = 67
+@Field static final int MSG_TEXT_STATE_RESPONSE = 98
 @Field static final int MSG_TEXT_COMMAND_REQUEST = 99
 
 @Field static final int ENTITY_CATEGORY_NONE = 0

--- a/ESPHome/ESPHome-API-Library.groovy
+++ b/ESPHome/ESPHome-API-Library.groovy
@@ -829,6 +829,20 @@ private static Map parseEntity(Map<Integer, List> tags) {
     ]
 }
 
+@CompileStatic
+void espHomeClimateState(Map<Integer, List> tags) {
+    return [
+            type: 'state',
+            platform: 'climate',
+            key: getLongTag(tags, 1),
+            climateMode: toClimateMode(getIntTag(tags, 2)),
+            currentTemperature: getFloatTag(tags, 3),
+            targetTemperature: getFloatTag(tags, 4),
+            targetTemperatureLow: getFloatTag(tags, 5),
+            targetTemperatureHigh: getFloatTag(tags, 6),
+    ]
+}
+
 /**
  * Minimal Protobuf Implementation for use with ESPHome
  */
@@ -950,6 +964,20 @@ private static String toEntityCategory(int value) {
         case ENTITY_CATEGORY_NONE: return 'none'
         case ENTITY_CATEGORY_CONFIG: return 'config'
         case ENTITY_CATEGORY_DIAGNOSTIC: return 'diagnostic'
+        default: return value
+    }
+}
+
+@CompileStatic
+private static String toClimateMode(int value) {
+    switch (value) {
+        case CLIMATE_MODE_OFF: return 'off'
+        case CLIMATE_MODE_AUTO: return 'auto'
+        case CLIMATE_MODE_COOL: return 'cool'
+        case CLIMATE_MODE_HEAT_COOL: return 'heat cool'
+        case CLIMATE_MODE_HEAT: return 'heat'
+        case CLIMATE_MODE_FAN_ONLY: return 'fan only'
+        case CLIMATE_MODE_DRY: return 'dry'
         default: return value
     }
 }
@@ -1083,6 +1111,9 @@ private void parseMessage(ByteArrayInputStream stream, long length) {
             break
         case MSG_SELECT_STATE_RESPONSE:
             parse espHomeSelectState(tags)
+            break
+        case MSG_CLIMATE_STATE_RESPONSE:
+            parse espHomeClimateState(tags)
             break
         default:
             if (!handled) {
@@ -1529,7 +1560,7 @@ private void logWarning(String s) {
 @Field static final int MSG_CAMERA_IMAGE_RESPONSE = 44
 @Field static final int MSG_CAMERA_IMAGE_REQUEST = 45
 @Field static final int MSG_LIST_CLIMATE_RESPONSE = 46 // TODO
-@Field static final int MSG_CLIMATE_STATE_RESPONSE = 47 // TODO
+@Field static final int MSG_CLIMATE_STATE_RESPONSE = 47
 @Field static final int MSG_CLIMATE_COMMAND_REQUEST = 48 // TODO
 @Field static final int MSG_LIST_NUMBER_RESPONSE = 49
 @Field static final int MSG_NUMBER_STATE_RESPONSE = 50

--- a/ESPHome/ESPHome-API-Library.groovy
+++ b/ESPHome/ESPHome-API-Library.groovy
@@ -830,7 +830,7 @@ private static Map parseEntity(Map<Integer, List> tags) {
 }
 
 @CompileStatic
-void espHomeClimateState(Map<Integer, List> tags) {
+private static Map espHomeClimateState(Map<Integer, List> tags) {
     return [
             type: 'state',
             platform: 'climate',

--- a/ESPHome/ESPHome-API-Library.groovy
+++ b/ESPHome/ESPHome-API-Library.groovy
@@ -303,7 +303,7 @@ void espHomeSwitchCommand(Map<String, Object> tags) {
 void espHomeTextCommand(Map<String, Object> tags) {
     sendMessage(MSG_TEXT_COMMAND_REQUEST, [
             1: [ tags.key as Integer, WIRETYPE_FIXED32 ],
-            3: [ tags.state as String, WIRETYPE_LENGTH_DELIMITED ]
+            2: [ tags.state as String, WIRETYPE_LENGTH_DELIMITED ]
     ], MSG_TEXT_SENSOR_STATE_RESPONSE)
 }
 

--- a/ESPHome/ESPHome-API-Library.groovy
+++ b/ESPHome/ESPHome-API-Library.groovy
@@ -298,6 +298,15 @@ void espHomeSwitchCommand(Map<String, Object> tags) {
             3: [ tags.state as String, WIRETYPE_LENGTH_DELIMITED ]
     ], MSG_SWITCH_STATE_RESPONSE)
 }
+
+@CompileStatic
+void espHomeTextCommand(Map<String, Object> tags) {
+    sendMessage(MSG_TEXT_COMMAND_REQUEST, [
+            1: [ tags.key as Integer, WIRETYPE_FIXED32 ],
+            3: [ tags.state as String, WIRETYPE_LENGTH_DELIMITED ]
+    ], MSG_TEXT_SENSOR_STATE_RESPONSE)
+}
+
 /*
  * ESPHome Message Parsing
  */
@@ -1593,7 +1602,7 @@ private void logWarning(String s) {
 @Field static final int MSG_CAMERA_IMAGE_REQUEST = 45
 @Field static final int MSG_LIST_CLIMATE_RESPONSE = 46 // TODO
 @Field static final int MSG_CLIMATE_STATE_RESPONSE = 47
-@Field static final int MSG_CLIMATE_COMMAND_REQUEST = 48 // TODO
+@Field static final int MSG_CLIMATE_COMMAND_REQUEST = 48
 @Field static final int MSG_LIST_NUMBER_RESPONSE = 49
 @Field static final int MSG_NUMBER_STATE_RESPONSE = 50
 @Field static final int MSG_NUMBER_COMMAND_REQUEST = 51
@@ -1613,6 +1622,7 @@ private void logWarning(String s) {
 @Field static final int MSG_MEDIA_COMMAND_REQUEST = 65
 @Field static final int MSG_SUBSCRIBE_BTLE_REQUEST = 66
 @Field static final int MSG_BLUETOOTH_LE_RESPONSE = 67
+@Field static final int MSG_TEXT_COMMAND_REQUEST = 99
 
 @Field static final int ENTITY_CATEGORY_NONE = 0
 @Field static final int ENTITY_CATEGORY_CONFIG = 1

--- a/ESPHome/ESPHome-API-Library.groovy
+++ b/ESPHome/ESPHome-API-Library.groovy
@@ -840,6 +840,7 @@ private static Map espHomeClimateState(Map<Integer, List> tags) {
             targetTemperature: getFloatTag(tags, 4), //for water heaters, set temp
             targetTemperatureLow: getFloatTag(tags, 5),
             targetTemperatureHigh: getFloatTag(tags, 6),
+            customMode: getStringTag(tags, 13)
     ]
 }
 

--- a/ESPHome/ESPHome-Rheem-Waterheater.groovy
+++ b/ESPHome/ESPHome-Rheem-Waterheater.groovy
@@ -147,9 +147,12 @@ public void setVacationMode(String value) {
     espHomeSwitchCommand(key: state.vacation, state: value)
 }
 
-public void setHeatingSetpoint(BigDecimal value) {
-    if (logTextEnable) { log.info "${device} setThermostatHeatingSetpoint to ${value}" }
-    espHomeClimateCommand(key: state.climate, targetTemperature: ((value.doubleValue() - 32) / 1.8) as Double)
+public void setHeatingSetpoint(float value) {
+
+    valueC = ((value - 32) / 1.8) as float
+    if (logTextEnable) { log.info "${device} setThermostatHeatingSetpoint to ${value} (${valueC} celsius)" }
+    //ESPHome expects Celsius
+    espHomeClimateCommand(key: state.climate, targetTemperature: valueC)
 }
 
 

--- a/ESPHome/ESPHome-Rheem-Waterheater.groovy
+++ b/ESPHome/ESPHome-Rheem-Waterheater.groovy
@@ -43,6 +43,8 @@ metadata {
         attribute 'waterHeaterMode', 'enum', ['Heat Pump', 'Energy Saver', 'High Demand', 'Normal', 'Vacation', 'Off']
         attribute 'lowerTankTemperature', 'number'
         attribute 'upperTankTemperature', 'number'
+        attribute 'thermostatHeatingSetpoint', 'number'
+
         attribute 'powerWatts', 'number'
         attribute 'hotWaterAvailabilityPercent', 'number'
 
@@ -152,6 +154,7 @@ public void parse(Map message) {
             break
 
         case 'state':
+            
             // Signal Strength
             if (state.signalStrength as Long == message.key && message.hasState) {
                 Integer rssi = Math.round(message.state as Float)
@@ -164,16 +167,28 @@ public void parse(Map message) {
                 return
             }
 
-            if (settings.temperature as Long == message.key && message.hasState) {
-                String value = message.state
-                if (device.currentValue('temperature') != value) {
 
-                    //updateAttribute('temperature', value, '°C', 'temperature')
+            
 
-
+            if (message.platform == 'climate') {
+                
+                if (message.targetTemperature) {
+                    Double temperatureF = Math.round(message.targetTemperature.toDouble() * 10) / 10.0
+                    if (device.currentValue('thermostatHeatingSetpoint') != temperatureF) {
+                        updateAttribute('thermostatHeatingSetpoint', temperatureF, 'F')
+                    }
                 }
+
+                if (message.temperature) {                    
+                    Double temperatureF = Math.round(message.temperature.toDouble() * 10) / 10.0
+                    if (device.currentValue('upperTankTemperature') != temperatureF) {
+                        updateAttribute('upperTankTemperature', temperatureF, 'F')
+                    }
+                }
+
                 return
             }
+
     }
 }
 
@@ -187,9 +202,9 @@ public void parse(Map message) {
  */
 private void updateAttribute(final String attribute, final Object value, final String unit = null, final String type = null) {
     final String descriptionText = "${attribute} was set to ${value}${unit ?: ''}"
-    if (device.currentValue(attribute) != value && settings.txtEnable) {
-        log.info descriptionText
-    }
+    //if (device.currentValue(attribute) != value && settings.txtEnable) {
+    log.info descriptionText
+    //}
     sendEvent(name: attribute, value: value, unit: unit, type: type, descriptionText: descriptionText)
 }
 

--- a/ESPHome/ESPHome-Rheem-Waterheater.groovy
+++ b/ESPHome/ESPHome-Rheem-Waterheater.groovy
@@ -32,10 +32,8 @@ metadata {
         capability 'Initialize'
         capability 'SignalStrength'
         capability 'TemperatureMeasurement'
-        capability 'Switch'
         capability 'ThermostatHeatingSetpoint'
         capability 'ThermostatOperatingState'
-        capability 'ThermostatMode'
         
         command 'setWaterHeaterMode', [[name:'Mode*','type':'ENUM','description':'Mode','constraints':['Heat Pump', 'Energy Saver', 'High Demand', 'Normal', 'Vacation', 'Off']]]
 
@@ -173,16 +171,25 @@ public void parse(Map message) {
             if (message.platform == 'climate') {
                 
                 if (message.targetTemperature) {
-                    Double temperatureF = Math.round(message.targetTemperature.toDouble() * 10) / 10.0
+                    Double temperatureF = Math.round((message.targetTemperature.toDouble() * 1.8 + 32) * 10) / 10.0
                     if (device.currentValue('thermostatHeatingSetpoint') != temperatureF) {
                         updateAttribute('thermostatHeatingSetpoint', temperatureF, 'F')
                     }
                 }
 
                 if (message.temperature) {                    
-                    Double temperatureF = Math.round(message.temperature.toDouble() * 10) / 10.0
+                    Double temperatureF = Math.round((message.temperature.toDouble() * 1.8 + 32) * 10) / 10.0
                     if (device.currentValue('upperTankTemperature') != temperatureF) {
                         updateAttribute('upperTankTemperature', temperatureF, 'F')
+                    }
+                }
+
+                if (message.customMode) {                    
+                    if (message.customMode == 'Eco Mode'){
+                        message.customMode = 'Energy Saver'
+                    }
+                    if (device.currentValue('waterHeaterMode') != message.customMode) {
+                        updateAttribute('waterHeaterMode', message.customMode)
                     }
                 }
 

--- a/ESPHome/ESPHome-Rheem-Waterheater.groovy
+++ b/ESPHome/ESPHome-Rheem-Waterheater.groovy
@@ -1,6 +1,6 @@
 /**
  *  MIT License
- *  Copyright 2022 Jonathan Bradshaw (jb@nrgup.net)
+ *  Copyright 2024 Kris Linquist (kris@linquist.net)
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal
@@ -36,11 +36,11 @@ metadata {
         capability 'ThermostatHeatingSetpoint'
         capability 'ThermostatOperatingState'
         
-        command 'setWaterHeaterMode', [[name:'Mode*','type':'ENUM','description':'Mode','constraints':['Heat Pump', 'Energy Saver', 'High Demand', 'Off']]]
+        command 'setWaterHeaterMode', [[name:'Mode*','type':'ENUM','description':'Mode','constraints':['Heat Pump', 'Energy Saver', 'High Demand', 'Electric/Gas', 'Off']]]
         command 'setVacationMode', [[name:'VacationMode*','type':'ENUM','description':'VacationMode','constraints':['Off', 'Permanent']]]
 
         attribute 'networkStatus', 'enum', [ 'connecting', 'online', 'offline' ]
-        attribute 'waterHeaterMode', 'enum', ['Heat Pump', 'Energy Saver', 'High Demand', 'Normal', 'Off']
+        attribute 'waterHeaterMode', 'enum', ['Heat Pump', 'Energy Saver', 'High Demand', 'Electric/Gas', 'Off']
         attribute 'lowerTankTemperature', 'number'
         attribute 'upperTankTemperature', 'number'
         attribute 'powerWatts', 'number'

--- a/ESPHome/ESPHome-Rheem-Waterheater.groovy
+++ b/ESPHome/ESPHome-Rheem-Waterheater.groovy
@@ -1,0 +1,199 @@
+/**
+ *  MIT License
+ *  Copyright 2022 Jonathan Bradshaw (jb@nrgup.net)
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+metadata {
+    definition(
+        name: 'ESPHome Rheem Water Heater',
+        namespace: 'esphome',
+        author: 'Kris Linquist',
+        singleThreaded: true,
+        importUrl: 'https://raw.githubusercontent.com/bradsjm/hubitat-drivers/main/ESPHome/ESPHome-Rheem-Waterheater.groovy') {
+
+        capability 'Refresh'
+        capability 'Initialize'
+        capability 'SignalStrength'
+        capability 'TemperatureMeasurement'
+        capability 'Switch'
+        capability 'ThermostatHeatingSetpoint'
+        capability 'ThermostatOperatingState'
+        capability 'ThermostatMode'
+        
+        command 'setWaterHeaterMode', [[name:'Mode*','type':'ENUM','description':'Mode','constraints':['Heat Pump', 'Energy Saver', 'High Demand', 'Normal', 'Vacation', 'Off']]]
+
+        attribute 'networkStatus', 'enum', [ 'connecting', 'online', 'offline' ]
+        attribute 'waterHeaterMode', 'enum', ['Heat Pump', 'Energy Saver', 'High Demand', 'Normal', 'Vacation', 'Off']
+        attribute 'lowerTankTemperature', 'number'
+        attribute 'upperTankTemperature', 'number'
+        attribute 'powerWatts', 'number'
+        attribute 'hotWaterAvailabilityPercent', 'number'
+
+    }
+
+    preferences {
+        input name: 'ipAddress',    // required setting for API library
+                type: 'text',
+                title: 'Device IP Address',
+                required: true
+
+        input name: 'password',     // optional setting for API library
+                type: 'text',
+                title: 'Device Password <i>(if required)</i>',
+                required: false
+
+        input name: 'logEnable',    // if enabled the library will log debug details
+                type: 'bool',
+                title: 'Enable Debug Logging',
+                required: false,
+                defaultValue: false
+
+        input name: 'logTextEnable',
+              type: 'bool',
+              title: 'Enable descriptionText logging',
+              required: false,
+              defaultValue: true
+    }
+}
+
+import com.hubitat.app.ChildDeviceWrapper
+
+public void initialize() {
+    // API library command to open socket to device, it will automatically reconnect if needed
+    openSocket()
+
+    if (logEnable) {
+        runIn(1800, 'logsOff')
+    }
+}
+
+public void installed() {
+    log.info "${device} driver installed"
+}
+
+public void logsOff() {
+    espHomeSubscribeLogs(LOG_LEVEL_INFO, false) // disable device logging
+    device.updateSetting('logEnable', false)
+    log.info "${device} debug logging disabled"
+}
+
+public void refresh() {
+    log.info "${device} refresh"
+    state.clear()
+    state.requireRefresh = true
+    espHomeDeviceInfoRequest()
+}
+
+public void updated() {
+    log.info "${device} driver configuration updated"
+    initialize()
+}
+
+public void uninstalled() {
+    closeSocket('driver uninstalled') // make sure the socket is closed when uninstalling
+    log.info "${device} driver uninstalled"
+}
+
+// driver commands
+public void on() {
+    if (device.currentValue('switch') != 'on') {
+        if (logTextEnable) { log.info "${device} on" }
+        espHomeSwitchCommand(key: settings.switch as Long, state: true)
+    }
+}
+
+public void off() {
+    if (device.currentValue('switch') != 'off') {
+        if (logTextEnable) { log.info "${device} off" }
+        espHomeSwitchCommand(key: settings.switch as Long, state: false)
+    }
+}
+
+
+// the parse method is invoked by the API library when messages are received
+public void parse(Map message) {
+    if (logEnable) { log.debug "ESPHome received: ${message}" }
+
+    switch (message.type) {
+        case 'device':
+            // Device information
+            break
+
+        case 'entity':
+            
+            if (message.platform == 'binary' && !message.disabledByDefault && message.entityCategory == 'none') {
+
+            }
+
+            if (message.platform == 'sensor') {
+                switch (message.deviceClass) {
+                    case 'signal_strength':
+                        state['signalStrength'] = message.key
+                        break
+                }
+            }
+            break
+
+        case 'state':
+            // Signal Strength
+            if (state.signalStrength as Long == message.key && message.hasState) {
+                Integer rssi = Math.round(message.state as Float)
+                String unit = 'dBm'
+                if (device.currentValue('rssi') != rssi) {
+                    descriptionText = "${device} rssi is ${rssi}"
+                    sendEvent(name: 'rssi', value: rssi, unit: unit, descriptionText: descriptionText)
+                    if (logTextEnable) { log.info descriptionText }
+                }
+                return
+            }
+
+            if (settings.temperature as Long == message.key && message.hasState) {
+                String value = message.state
+                if (device.currentValue('temperature') != value) {
+
+                    //updateAttribute('temperature', value, '°C', 'temperature')
+
+
+                }
+                return
+            }
+    }
+}
+
+
+/**
+ * Update the specified device attribute with the specified value and log if changed
+ * @param attribute name of the attribute
+ * @param value value of the attribute
+ * @param unit unit of the attribute
+ * @param type type of the attribute
+ */
+private void updateAttribute(final String attribute, final Object value, final String unit = null, final String type = null) {
+    final String descriptionText = "${attribute} was set to ${value}${unit ?: ''}"
+    if (device.currentValue(attribute) != value && settings.txtEnable) {
+        log.info descriptionText
+    }
+    sendEvent(name: attribute, value: value, unit: unit, type: type, descriptionText: descriptionText)
+}
+
+
+
+// Put this line at the end of the driver to include the ESPHome API library helper
+#include esphome.espHomeApiHelper

--- a/ESPHome/ESPHome-Rheem-Waterheater.groovy
+++ b/ESPHome/ESPHome-Rheem-Waterheater.groovy
@@ -211,13 +211,13 @@ public void parse(Map message) {
             if (state.power as Long == message.key && message.hasState) {
                 Integer power = Math.round(message.state as Float)
                 if (device.currentValue('powerWatts') != power) {
-                    updateAttribute('thermostatHeatingSetpoint', power, 'F')
+                    updateAttribute('powerWatts', power, 'W')
                 }
                 return
             }
 
             if (state.lowerTankTemperature as Long == message.key && message.hasState) {
-                Double temperatureF = Math.round(message.state)
+                Double temperatureF = Math.round(message.state * 10) / 10.0
                 if (device.currentValue('lowerTankTemperature') != temperatureF) {
                     updateAttribute('lowerTankTemperature', temperatureF, 'F')
                 }
@@ -225,7 +225,7 @@ public void parse(Map message) {
             }
 
             if (state.upperTankTemperature as Long == message.key && message.hasState) {
-                Double temperatureF = Math.round(message.state)
+                Double temperatureF = Math.round(message.state * 10) / 10.0
                 if (device.currentValue('upperTankTemperature') != temperatureF) {
                     updateAttribute('upperTankTemperature', temperatureF, 'F')
                 }
@@ -257,7 +257,7 @@ public void parse(Map message) {
             }
 
             if (state.ambientTemperature as Long == message.key && message.hasState) {
-                Double temperatureF = Math.round(message.state)
+                Double temperatureF = Math.round(message.state * 10) / 10.0
                 if (device.currentValue('ambientTemperature') != temperatureF) {
                     updateAttribute('ambientTemperature', temperatureF, 'F')
                 }
@@ -270,10 +270,16 @@ public void parse(Map message) {
                 }
                 return
             }
-            
+
 
             if (message.platform == 'climate') {
                 state['climate'] = message.key
+                if (message.targetTemperature) {
+                    Double temperatureF = Math.round((message.targetTemperature.toDouble() * 1.8 + 32) * 10) / 10.0
+                    if (device.currentValue('thermostatHeatingSetpoint') != temperatureF) {
+                        updateAttribute('thermostatHeatingSetpoint', temperatureF, 'F')
+                    }
+                }
 
                 if (message.customMode) {                    
                     if (message.customMode == 'Eco Mode'){

--- a/ESPHome/ESPHome-Rheem-Waterheater.groovy
+++ b/ESPHome/ESPHome-Rheem-Waterheater.groovy
@@ -302,7 +302,7 @@ public void parse(Map message) {
             }
 
             if (state.compressorState as Long == message.key && message.hasState) {
-                if (device.currentValue('heatingElementState') != message.state) {
+                if (device.currentValue('compressorState') != message.state) {
                     updateAttribute('compressorState', message.state)
                 }
                 return

--- a/ESPHome/ESPHome-Rheem-Waterheater.groovy
+++ b/ESPHome/ESPHome-Rheem-Waterheater.groovy
@@ -139,12 +139,12 @@ public void setWaterHeaterMode(String value) {
         value = 'Eco Mode'
     }
     if (logTextEnable) { log.info "${device} setWaterHeaterMode to ${value}" }
-    espHomeClimateCommand(key: state.climate, customPreset: value)
+    espHomeClimateCommand(key: state.climate as Long, customPreset: value)
 }
 
 public void setVacationMode(String value) {
-    if (logTextEnable) { log.info "${device} setVacationMode to ${value}" }
-    espHomeTextCommand(key: state.vacation, state: value)
+    if (logTextEnable) { log.info "${device} setVacationMode to ${value} using key ${state.vacation}" }
+    espHomeSelectCommand(key: state.vacation as Long, state: value)
 }
 
 public void setHeatingSetpoint(float value) {
@@ -152,7 +152,7 @@ public void setHeatingSetpoint(float value) {
     valueC = ((value - 32) / 1.8) as float
     if (logTextEnable) { log.info "${device} setThermostatHeatingSetpoint to ${value} (${valueC} celsius)" }
     //ESPHome expects Celsius
-    espHomeClimateCommand(key: state.climate, targetTemperature: valueC)
+    espHomeClimateCommand(key: state.climate as Long, targetTemperature: valueC)
 }
 
 

--- a/ESPHome/ESPHome-Rheem-Waterheater.groovy
+++ b/ESPHome/ESPHome-Rheem-Waterheater.groovy
@@ -204,10 +204,10 @@ public void parse(Map message) {
                 case 'mode':
                     state['mode'] = message.key
                     break
-                case state['heating_element_state']:
+                case 'heating_element_state':
                     state['heatingElementState'] = message.key
                     break
-                case state['compressor']:
+                case 'compressor':
                     state['compressorState'] = message.key
                     break                    
                 default:

--- a/ESPHome/ESPHome-Rheem-Waterheater.groovy
+++ b/ESPHome/ESPHome-Rheem-Waterheater.groovy
@@ -123,14 +123,14 @@ public void uninstalled() {
 public void on() {
     if (device.currentValue('switch') != 'on') {
         if (logTextEnable) { log.info "${device} on" }
-        espHomeClimateCommand(key: state.climate as Long, customMode: 'Eco Mode')
+        espHomeClimateCommand(key: state.climate as Long, customPreset: 'Eco Mode')
     }
 }
 
 public void off() {
     if (device.currentValue('switch') != 'off') {
         if (logTextEnable) { log.info "${device} off" }
-        espHomeSwitchCommand(key: state.climate as Long, customMode: 'Off')
+        espHomeSwitchCommand(key: state.climate as Long, customPreset: 'Off')
     }
 }
 
@@ -139,7 +139,7 @@ public void setWaterHeaterMode(String value) {
         value = 'Eco Mode'
     }
     if (logTextEnable) { log.info "${device} setWaterHeaterMode to ${value}" }
-    espHomeClimateCommand(key: state.climate, customMode: value)
+    espHomeClimateCommand(key: state.climate, customPreset: value)
 }
 
 public void setVacationMode(String value) {
@@ -292,12 +292,12 @@ public void parse(Map message) {
                     }
                 }
 
-                if (message.customMode) {                    
-                    if (message.customMode == 'Eco Mode'){
-                        message.customMode = 'Energy Saver'
+                if (message.customPreset) {                    
+                    if (message.customPreset == 'Eco Mode'){
+                        message.customPreset = 'Energy Saver'
                     }
-                    if (device.currentValue('waterHeaterMode') != message.customMode) {
-                        updateAttribute('waterHeaterMode', message.customMode)
+                    if (device.currentValue('waterHeaterMode') != message.customPreset) {
+                        updateAttribute('waterHeaterMode', message.customPreset)
                     }
                 }
 

--- a/ESPHome/ESPHome-Rheem-Waterheater.groovy
+++ b/ESPHome/ESPHome-Rheem-Waterheater.groovy
@@ -265,7 +265,7 @@ public void parse(Map message) {
             }
 
             if (state.vacation as Long == message.key && message.hasState) {
-                if (device.currentValue('vacationMode') != mode) {
+                if (device.currentValue('vacationMode') != message.state) {
                     updateAttribute('vacationMode', message.state)
                 }
                 return

--- a/ESPHome/ESPHome-Rheem-Waterheater.groovy
+++ b/ESPHome/ESPHome-Rheem-Waterheater.groovy
@@ -144,7 +144,7 @@ public void setWaterHeaterMode(String value) {
 
 public void setVacationMode(String value) {
     if (logTextEnable) { log.info "${device} setVacationMode to ${value}" }
-    espHomeSwitchCommand(key: state.vacation, state: value)
+    espHomeTextCommand(key: state.vacation, state: value)
 }
 
 public void setHeatingSetpoint(float value) {


### PR DESCRIPTION
Everything works _except_ setting vacation mode.  I see that the mode comes in as `ListEntitiesSelectResponse` (ID 52)

```
ESPHome received: [objectId:vacation, key:2331543652, name:Vacation, uniqueId:econet-hpwhselectvacation, type:entity, platform:select, icon:mdi:bag-suitcase, options:[Off, Timed, Permanent], disabledByDefault:false, entityCategory:none]
dev:2862024-02-13 08:53:13.657 PMwarnESPHome received message type 52 with [1:[[118, 97, 99, 97, 116, 105, 111, 110]], 2:[2331543652], 3:[[86, 97, 99, 97, 116, 105, 111, 110]], 4:[[101, 99, 111, 110, 101, 116, 45, 104, 112, 119, 104, 115, 101, 108, 101, 99, 116, 118, 97, 99, 97, 116, 105, 111, 110]], 5:[[109, 100, 105, 58, 98, 97, 103, 45, 115, 117, 105, 116, 99, 97, 115, 101]], 6:[[79, 102, 102], [84, 105, 109, 101, 100], [80, 101, 114, 109, 97, 110, 101, 110, 116]]]
```

I created a function for [ID=53](https://github.com/esphome/aioesphomeapi/blob/main/aioesphomeapi/api.proto#L973) and [ID = 54](https://github.com/esphome/aioesphomeapi/blob/main/aioesphomeapi/api.proto#L985C9-L985C29).  


I am sending in the string of either `Off` or `Permanent`.    The result is just retries, which it seems is what happens with an incorrect payload.

The author of ESPHome Econet (on his Discord) said, "sending a string? [That should just be an enum [0,1,2]](https://github.com/esphome-econet/esphome-econet/blob/main/econet_electric_tank_water_heater.yaml)" so I assume a translation is supposed to happen somewhere.

Any ideas?