### PR TITLE
Parse device class from ESPHome binary_sensor entity response

### DIFF
--- a/ESPHome/ESPHome-API-Library.groovy
+++ b/ESPHome/ESPHome-API-Library.groovy
@@ -543,6 +543,7 @@ private static Map espHomeListEntitiesBinarySensorResponse(Map<Integer, List> ta
     return parseEntity(tags) + [
             type: 'entity',
             platform: 'binary',
+            deviceClass: getStringTag(tags, 5),
             isStatusBinarySensor: getBooleanTag(tags, 6),
             disabledByDefault: getBooleanTag(tags, 7),
             icon: getStringTag(tags, 8),


### PR DESCRIPTION
Parses the `deviceClass` from an ESPHome binary sensor entity payload.

ref: https://github.com/esphome/esphome/blob/dev/esphome/components/api/api.proto#L257-L273