### PR TITLE
Fix socket disconnect exception and reconnection issue

### DIFF
--- a/ESPHome/ESPHome-API-Library.groovy
+++ b/ESPHome/ESPHome-API-Library.groovy
@@ -81,9 +81,9 @@ void closeSocket(String reason) {
     if (!isOffline()) {
         sendMessage(MSG_DISCONNECT_REQUEST)
     }
-    interfaces.rawSocket.disconnect()
     setNetworkStatus('offline', reason)
     device.updateDataValue 'Last Disconnected Time', "${new Date()} (${reason})"
+    interfaces.rawSocket.close()
     pauseExecution(1000)
 }
 


### PR DESCRIPTION
1. The Hubitat API for sockets requires explicitly calling the close() method to disconnect. Reference: https://docs2.hubitat.com/en/developer/interfaces/raw-socket-interface
2. Invoking close() or disconnect() too early (before the remaining logic in the method executes) causes a Java exception (java.lang.RuntimeException: java.lang.InterruptedException). This exception prevents the socket from reconnecting properly without manual reinitialization.

Before:
<img width="1114" alt="Screenshot 2025-04-02 at 19 35 19" src="https://github.com/user-attachments/assets/bba67561-0802-4e57-b9b0-0699a16f7813" />

After:
<img width="1099" alt="Screenshot 2025-04-02 at 19 37 37" src="https://github.com/user-attachments/assets/7c03b958-2200-40db-9b3d-23fb41f25997" />
