### PR TITLE
Impliment espHomeSelectCommand

### DIFF
--- a/ESPHome/ESPHome-API-Library.groovy
+++ b/ESPHome/ESPHome-API-Library.groovy
@@ -81,9 +81,9 @@ void closeSocket(String reason) {
     if (!isOffline()) {
         sendMessage(MSG_DISCONNECT_REQUEST)
     }
-    interfaces.rawSocket.disconnect()
     setNetworkStatus('offline', reason)
     device.updateDataValue 'Last Disconnected Time', "${new Date()} (${reason})"
+    interfaces.rawSocket.close()
     pauseExecution(1000)
 }
 
@@ -239,14 +239,6 @@ void espHomeSirenCommand(Map<String, Object> tags) {
     ], MSG_SIREN_STATE_RESPONSE)
 }
 
-@CompileStatic
-void espHomeSwitchCommand(Map<String, Object> tags) {
-    sendMessage(MSG_SWITCH_COMMAND_REQUEST, [
-            1: [ tags.key as Integer, WIRETYPE_FIXED32 ],
-            2: [ tags.state ? 1 : 0, WIRETYPE_VARINT ],
-    ], MSG_SWITCH_STATE_RESPONSE)
-}
-
 void espHomeSubscribe() {
     log.info 'Subscribing to ESPHome HA services'
     espHomeSubscribeHaServicesRequest()
@@ -273,6 +265,14 @@ void espHomeCallService(String serviceName) {
 @CompileStatic
 void espHomeSubscribeBtleRequest() {
     sendMessage(MSG_SUBSCRIBE_BTLE_REQUEST)
+}
+
+@CompileStatic
+void espHomeSwitchCommand(Map<String, Object> tags) {
+    sendMessage(MSG_SWITCH_COMMAND_REQUEST, [
+            1: [ tags.key as Integer, WIRETYPE_FIXED32 ],
+            2: [ tags.state ? 1 : 0, WIRETYPE_VARINT ],
+    ], MSG_SWITCH_STATE_RESPONSE)
 }
 
 /*

--- a/ESPHome/ESPHome-API-Library.groovy
+++ b/ESPHome/ESPHome-API-Library.groovy
@@ -81,9 +81,9 @@ void closeSocket(String reason) {
     if (!isOffline()) {
         sendMessage(MSG_DISCONNECT_REQUEST)
     }
+    interfaces.rawSocket.disconnect()
     setNetworkStatus('offline', reason)
     device.updateDataValue 'Last Disconnected Time', "${new Date()} (${reason})"
-    interfaces.rawSocket.close()
     pauseExecution(1000)
 }
 
@@ -217,6 +217,14 @@ void espHomeNumberCommand(Map<String, Object> tags) {
 }
 
 @CompileStatic
+void espHomeSelectCommand(Map<String, Object> tags) {
+    sendMessage(MSG_SELECT_COMMAND_REQUEST, [
+            1: [tags.key as Integer, WIRETYPE_FIXED32 ],
+            2: [tags.state as String, WIRETYPE_LENGTH_DELIMITED ]
+    ], MSG_SELECT_STATE_RESPONSE)
+}
+
+@CompileStatic
 void espHomeSirenCommand(Map<String, Object> tags) {
     sendMessage(MSG_SIREN_COMMAND_REQUEST, [
             1: [ tags.key as Integer, WIRETYPE_FIXED32 ],
@@ -229,6 +237,14 @@ void espHomeSirenCommand(Map<String, Object> tags) {
             8: [ tags.volume != null ? 1 : 0, WIRETYPE_VARINT ],
             9: [ tags.volume as Float, WIRETYPE_FIXED32 ]
     ], MSG_SIREN_STATE_RESPONSE)
+}
+
+@CompileStatic
+void espHomeSwitchCommand(Map<String, Object> tags) {
+    sendMessage(MSG_SWITCH_COMMAND_REQUEST, [
+            1: [ tags.key as Integer, WIRETYPE_FIXED32 ],
+            2: [ tags.state ? 1 : 0, WIRETYPE_VARINT ],
+    ], MSG_SWITCH_STATE_RESPONSE)
 }
 
 void espHomeSubscribe() {
@@ -257,14 +273,6 @@ void espHomeCallService(String serviceName) {
 @CompileStatic
 void espHomeSubscribeBtleRequest() {
     sendMessage(MSG_SUBSCRIBE_BTLE_REQUEST)
-}
-
-@CompileStatic
-void espHomeSwitchCommand(Map<String, Object> tags) {
-    sendMessage(MSG_SWITCH_COMMAND_REQUEST, [
-            1: [ tags.key as Integer, WIRETYPE_FIXED32 ],
-            2: [ tags.state ? 1 : 0, WIRETYPE_VARINT ],
-    ], MSG_SWITCH_STATE_RESPONSE)
 }
 
 /*
@@ -1536,8 +1544,8 @@ private void logWarning(String s) {
 @Field static final int MSG_NUMBER_STATE_RESPONSE = 50
 @Field static final int MSG_NUMBER_COMMAND_REQUEST = 51
 @Field static final int MSG_LIST_SELECT_RESPONSE = 52
-@Field static final int MSG_SELECT_STATE_RESPONSE = 53 // TODO
-@Field static final int MSG_SELECT_COMMAND_REQUEST = 54 // TODO
+@Field static final int MSG_SELECT_STATE_RESPONSE = 53
+@Field static final int MSG_SELECT_COMMAND_REQUEST = 54
 @Field static final int MSG_LIST_SIREN_RESPONSE = 55
 @Field static final int MSG_SIREN_STATE_RESPONSE = 56
 @Field static final int MSG_SIREN_COMMAND_REQUEST = 57


### PR DESCRIPTION
Implements espHomeSelectCommand() taking a `key` and `state`, enabling the driver to send select entity updates to ESPHome devices.